### PR TITLE
Fix Linux musl build on Swift 6.3

### DIFF
--- a/Sources/Shared/Managers/DBManager.swift
+++ b/Sources/Shared/Managers/DBManager.swift
@@ -179,12 +179,9 @@ public actor DBManager {
 			response.headers
 			.first(name: "content-length")
 			.flatMap(Int.init) ?? 1024 * 1024 * 10
-		var bytes = try await response.body.collect(upTo: expectedBytes)
+		let bytes = try await response.body.collect(upTo: expectedBytes)
 
-		guard let data = bytes.readData(length: bytes.readableBytes) else {
-			logger.error("Failed to read response data.")
-			return nil
-		}
+		let data = Data(bytes.readableBytesView)
 
 		let decoder = JSONDecoder()
 		let subscriptions = try decoder.decode(
@@ -208,12 +205,9 @@ public actor DBManager {
 			response.headers
 			.first(name: "content-length")
 			.flatMap(Int.init) ?? 1024 * 1024 * 10
-		var bytes = try await response.body.collect(upTo: expectedBytes)
+		let bytes = try await response.body.collect(upTo: expectedBytes)
 
-		guard let data = bytes.readData(length: bytes.readableBytes) else {
-			logger.error("Failed to read response data.")
-			return []
-		}
+		let data = Data(bytes.readableBytesView)
 
 		let decoder = JSONDecoder()
 		let subscriptions = try decoder.decode(
@@ -237,12 +231,9 @@ extension DBManager {
 			response.headers
 			.first(name: "content-length")
 			.flatMap(Int.init) ?? 1024 * 1024 * 10
-		var bytes = try await response.body.collect(upTo: expectedBytes)
+		let bytes = try await response.body.collect(upTo: expectedBytes)
 
-		guard let data = bytes.readData(length: bytes.readableBytes) else {
-			logger.error("Failed to read response data.")
-			return []
-		}
+		let data = Data(bytes.readableBytesView)
 
 		let decoder = JSONDecoder()
 		let decoded = try decoder.decode(

--- a/Sources/Shared/Managers/SearchManager.swift
+++ b/Sources/Shared/Managers/SearchManager.swift
@@ -67,21 +67,21 @@ public actor SearchManager {
 
 		let body = response.body
 		let expectedBytes = response.headers.first(name: "content-length").flatMap(Int.init)
-		var bytes = try await body.collect(upTo: expectedBytes ?? 1024 * 1024 * 10)
+		let bytes = try await body.collect(upTo: expectedBytes ?? 1024 * 1024 * 10)
 
-		guard let data = bytes.readData(length: bytes.readableBytes) else {
+		let data = Data(bytes.readableBytesView)
+
+		guard !data.isEmpty else {
 			throw SearchError.noData
 		}
 
-		guard var dataString = String(data: data, encoding: .utf8) else {
+		guard var dataString = String(data: data, encoding: String.Encoding.utf8) else {
 			return []
 		}
 
 		dataString = processJSONString(dataString)
 
-		guard let correctedData = dataString.data(using: .utf8) else {
-			return []
-		}
+		let correctedData = Data(dataString.utf8)
 
 		return try JSONDecoder().decode(SearchResultResponse.self, from: correctedData).results
 	}


### PR DESCRIPTION
## Summary
- replace Linux-incompatible `ByteBuffer.readData` usage with `Data(bytes.readableBytesView)`
- make the UTF-8 conversions explicit and warning-free under Swift 6.3
- keep the macOS build and tests green while fixing the Linux musl release build

## Validation
- `swift build`
- `swift test`
- `swift build --swift-sdk x86_64-swift-linux-musl -c release`