### PR TITLE
Drop the delete-conflict workaround, now fixed upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build on Ubuntu with latest Swift (Docker)
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   swift-docker:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "500ab4c1be46b217d373b0007c169f556994c101e6007e041bfd3e5127af10e4",
+  "originHash" : "8ec428bfcefd8be60316e2f9516b991791f66d812580425976def0b279f21816",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/makoni/couchdb-swift.git",
       "state" : {
-        "revision" : "30cb210ea88bdfd93c9c27a5a5a9c7931cc1dbff",
-        "version" : "3.0.2"
+        "revision" : "9f2bddce9b1a19adbd8181b38314cfef0516e9aa",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/nerzh/swift-telegram-sdk.git", .upToNextMajor(from: "10.0.0")),
-        .package(url: "https://github.com/makoni/couchdb-swift.git", from: "3.0.0"),
+        .package(url: "https://github.com/makoni/couchdb-swift.git", from: "3.1.0"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/Shared/Managers/CouchDocumentStore.swift
+++ b/Sources/Shared/Managers/CouchDocumentStore.swift
@@ -115,9 +115,9 @@ public struct CouchDBDocumentStore: CouchDocumentStore {
 	/// A second gate on the response size.
 	///
 	/// Not the real ceiling: `couchdb-swift` has already collected the whole body by the time
-	/// it hands the response back (capped at `content-length ?? 10 MB`, where the *header*
-	/// wins), and re-attached it in memory. So this bounds what we agree to decode, not what
-	/// was read. Page sizes are chosen against the library's 10 MB, not against this number.
+	/// it hands the response back, capped at its own `maxResponseBytes` (10 MB by default, and
+	/// as of 3.1.0 a `content-length` header can no longer raise it). So this bounds what we
+	/// agree to decode, not what was read — and page sizes are chosen against that 10 MB.
 	static let maxResponseBytes = 10 * 1024 * 1024
 
 	public func fetchView(uri: String, queryItems: [URLQueryItem]?) async throws -> (statusCode: Int, body: Data) {
@@ -148,25 +148,17 @@ public struct CouchDBDocumentStore: CouchDocumentStore {
 
 	/// Interprets a failure from `delete`.
 	///
-	/// The library special-cases only 404 on delete: for a 409 it falls through to decoding
-	/// `CouchUpdateResponse`, whose `ok`/`id`/`rev` are not optional, so a conflict arrives as
-	/// a `DecodingError` rather than a `CouchDBClientError`. Without translating that, the
-	/// retry loop cannot see a delete conflict at all — and delete is the write where it is
-	/// most needed, since consolidating duplicates removes documents another task may hold.
-	///
-	/// The library intercepts only 401 and 404 before that decode and then discards the status,
-	/// so a 400, 412 or 5xx on DELETE also arrives as a `DecodingError` and is reported here as
-	/// a conflict. That is imprecise but safe: such a delete is retried three times and then
-	/// surfaced, so nothing spins and nothing is lost — a CouchDB outage during consolidation
-	/// is simply logged as a conflict. Distinguishing them would mean bypassing `client.delete`.
+	/// Thin now: couchdb-swift 3.1.0 throws `.conflictError` for a 409 and `.noData` for an
+	/// empty body, so there is nothing left to guess at. Before that a delete conflict arrived
+	/// as a `DecodingError` and had to be read as contention, which also swallowed a genuine
+	/// 400 or 5xx — hence the pinned minimum of 3.1.0 in `Package.swift`. A decoding failure
+	/// means what it says again: the response did not match the model.
 	///
 	/// A free function so the translation is testable; the call itself needs a live server.
 	static func storeError(fromDeleteFailure error: any Error) -> StoreError {
 		switch error {
 		case let couch as CouchDBClientError:
 			return StoreError(couch)
-		case is DecodingError:
-			return .conflict
 		case let store as StoreError:
 			return store
 		default:
@@ -185,8 +177,9 @@ public struct CouchDBDocumentStore: CouchDocumentStore {
 		try Self.verify(response)
 	}
 
-	/// An empty response body yields `CouchUpdateResponse(ok: false, id: "", rev: "")` rather
-	/// than a throw, so discarding the result would read a failed delete as a success.
+	/// Belt and braces. The library throws `.noData` for an empty body as of 3.1.0, so this
+	/// only catches a `2xx` that somehow reports `ok: false` — but the alternative is
+	/// discarding the result entirely, which would read a failed delete as a success.
 	static func verify(_ response: CouchUpdateResponse) throws {
 		guard response.ok else {
 			throw StoreError.unexpectedResponse

--- a/Tests/ReleaseInformerBotTests/DBManagerLogicTests.swift
+++ b/Tests/ReleaseInformerBotTests/DBManagerLogicTests.swift
@@ -320,20 +320,20 @@ struct DeleteFailureMappingTests {
 		return try JSONDecoder().decode(CouchDBError.self, from: Data(json.utf8))
 	}
 
-	/// `couchdb-swift` handles only 404 on delete; a 409 body reaches `JSONDecoder` and fails
-	/// there, so without translating a decoding failure the retry loop never sees a delete
-	/// conflict — the write where consolidating duplicates needs it most.
-	@Test("A decoding failure from a delete is treated as a conflict")
-	func decodingFailureIsAConflict() {
-		// Exactly what the library produces: CouchDB's conflict body decoded as though it were
-		// a `CouchUpdateResponse`.
-		let conflictBody = Data(#"{"error":"conflict","reason":"Document update conflict."}"#.utf8)
+	/// Up to couchdb-swift 3.0.2 a 409 on delete arrived as a `DecodingError`, so we had to
+	/// read any decoding failure as a conflict — which also swallowed a genuine 400 or 5xx.
+	/// 3.1.0 throws `.conflictError` properly, so a decoding failure means what it says again:
+	/// the response did not match the model. Treating it as a conflict now would retry a real
+	/// bug three times and report it as contention.
+	@Test("A decoding failure is not mistaken for a conflict")
+	func decodingFailureIsNotAConflict() {
+		let garbage = Data(#"{"unexpected":true}"#.utf8)
 		do {
-			_ = try JSONDecoder().decode(CouchUpdateResponse.self, from: conflictBody)
-			Issue.record("Expected the conflict body to fail decoding")
+			_ = try JSONDecoder().decode(CouchUpdateResponse.self, from: garbage)
+			Issue.record("Expected the body to fail decoding")
 		} catch {
 			#expect(error is DecodingError)
-			#expect(CouchDBDocumentStore.storeError(fromDeleteFailure: error) == .conflict)
+			#expect(CouchDBDocumentStore.storeError(fromDeleteFailure: error) == .unexpectedResponse)
 		}
 	}
 


### PR DESCRIPTION
Follow-up to makoni/couchdb-swift#46, which shipped in couchdb-swift 3.1.0.

3.1.0 fixes the three things reported there:

- `delete` checks for `.conflict` before `.notFound`, so a 409 arrives as `conflictError` instead of falling through to the decoder.
- An empty response body throws `.noData` rather than returning `CouchUpdateResponse(ok: false, ...)`.
- `collectResponseBytes` uses `min(expectedBytes ?? cap, cap)`, so a `content-length` header can no longer raise the ceiling.

So `storeError(fromDeleteFailure:)` no longer has to read every `DecodingError` as contention — a workaround that also swallowed genuine 400, 412 and 5xx responses and reported them as conflicts. A decoding failure means what it says again.

The dependency minimum moves to `from: "3.1.0"`, because the code now depends on that behaviour. Left at `3.0.0`, a resolution back to 3.0.x would reintroduce the bug silently — the tests use a fake store, so nothing would fail.

Three comments that described 3.0.2 are corrected. The `response.ok` check stays as belt and braces, with an honest note about what it still catches.

Also worth knowing: 3.1.0 changed `insert` to throw `.conflictError` too, where it previously returned `.insertError` carrying CouchDB's `"conflict"` string. That is the path two concurrent `/add` commands take. `StoreError.init` already maps both shapes and `mapsConflicts` asserts it for all four operations, so the change is invisible here.

175 tests, clean debug and release builds on macOS. The behavioural change is verified by reintroducing the workaround, which fails the updated test.